### PR TITLE
修复了 n3Column 组件 offset 属性不起作用的bug

### DIFF
--- a/src/n3Column.vue
+++ b/src/n3Column.vue
@@ -27,7 +27,7 @@ export default{
       let klass = {}
 
       klass[prefixCls + '-col-' + mode + '-' + col] = true
-      offset ? klass[prefixCls + '-col-offset-' + offset] = true : ''
+      offset ? klass[prefixCls + '-col-' + mode + '-offset-' + offset] = true : ''
 
       return klass
     }


### PR DESCRIPTION
## 描述

n3Column 的 offset 属性没有产生与文档描述相符的效果。
## 原因

由 n3 样式表的[源码](https://github.com/N3-components/N3-components/blob/master/src/style/layout.less)可知，控制 offset 的类名格式为 `${prefix}-col-${mode}-offset-${offset}`， 而 n3Column 的[源码](https://github.com/N3-components/N3-components/blob/master/src/n3Column.vue)中，最终输出的类名为 `${prefix}-col-offset-${offset}`，无法与样式表的类名正确匹配，因此 offset 属性失效。
## 复现代码

``` vue
<template lang="jade">
n3-container
  n3-row
    n3-column(:col="6", :offset="6") 我在中间出现。
</template>

<script>
import {n3Container, n3Row, n3Column} from 'N3-Components'
export default {
  components: {
    n3Container: n3Container,
    n3Row: n3Row,
    n3Column: n3Column
  }
}
</script>
```
## 期望输出

在可视区域宽度大于992px时，从n3-container容器中线处开始输出字符串：『我在中间出现。』
## 实际输出

在可视区域宽度大于992px时，从n3-container容器最左边处开始输出字符串：『我在中间出现。』
