### PR TITLE
为 n3Panel 组件添加具名 slot 'header'

### DIFF
--- a/src/n3Panel.vue
+++ b/src/n3Panel.vue
@@ -3,11 +3,13 @@
     <div class="{{prefixCls}}-panel-heading">
       <h4 class="{{prefixCls}}-panel-title">
         <a @click="toggleIsOpen()">
-           {{ header }}
+           <slot name="header">
+            {{header}}
+           </slot>
         </a>
       </h4>
     </div>
-    <div 
+    <div
       class="{{prefixCls}}-panel-collapse"
       v-el:panel
       v-show="isOpen"


### PR DESCRIPTION
## Issue

Issue ID #27
## Solution

在原有组件 template 中渲染 header 属性的位置 wrap 一层 slot，保证原有属性可以继续被正常使用的同时增加 slot 模式。

``` html
<slot name="header">
{{header}}
</slot>
```
## Old Feature

``` html
<n3-panel header="我是纯文本 panel-header">
  我是panel-body
</n3-panel>
```
## New Feature

``` html
<n3-panel header="我是纯文本 panel-header，会被 slot 内容替换。">
  <div slot="header">我是 html 组成的 panel-header</div>
  我是panel-body
</n3-panel>
<n3-panel header="我是纯文本 panel-header，会被正常渲染。">
  我是panel-body
</n3-panel>
```
