### PR TITLE
tag closing fix in n3Panel.vue

### DIFF
--- a/src/Accordion/n3Panel.vue
+++ b/src/Accordion/n3Panel.vue
@@ -17,7 +17,7 @@
           <slot></slot>
         </div>
       </div>
-    <n3-collapse-transition>
+    </n3-collapse-transition>
   </div>
 </template>
 


### PR DESCRIPTION
`n3-collapse-transition` wasn't closed but inserted twice instead causing some Vue warning showing in console as error